### PR TITLE
Allow to pass second parameter to use as module name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ macro_rules! doc_comment {
     };
 }
 
-/// This macro provdes a simpler way to test an outer markdown file.
+/// This macro provides a simpler way to test an outer markdown file.
 ///
 /// # Example
 ///
@@ -168,11 +168,17 @@ macro_rules! doc_comment {
 /// // The two next lines are doing exactly the same thing:
 /// doc_comment!(include_str!("../README.md"));
 /// doctest!("../README.md");
+///
+/// // If you want to have a name for your tests:
+/// doctest!("../README.md", another);
 /// # fn main() {}
 /// ```
 #[macro_export]
 macro_rules! doctest {
     ($x:expr) => {
         doc_comment!(include_str!($x));
+    };
+    ($x:expr, $y:ident) => {
+        doc_comment!(include_str!($x), mod $y {});
     };
 }


### PR DESCRIPTION
Fixes #8.

It gives the following output:

```
   Compiling test-crate v0.1.0 (/home/imperio/rust/doc-comment/test-crate)
    Finished dev [unoptimized + debuginfo] target(s) in 0.26s
     Running target/debug/deps/test_crate-ac24b643594917a2

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests test-crate

running 1 test
test <::doc_comment::doc_comment macros> - foo (line 4) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

For the given input:

```rust
#[macro_use]
extern crate doc_comment;

doctest!("../README.md", foo);
```

Does it sound good to you @Alexander-N?